### PR TITLE
specify xy limits for plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: colorpath
 Title: Build Color Paths
-Version: 0.0.0.9012
+Version: 0.0.0.9013
 Authors@R: 
     person(given = "Ian J",
            family = "Lyttle",

--- a/R/plot.R
+++ b/R/plot.R
@@ -24,6 +24,7 @@ plot_cl <- function(pal_luv, n = 11, label_hue = FALSE) {
     # path will show up only for the control points because
     #   the color is constant for the control points
     ggplot2::geom_path(linetype = 2, alpha = 0.5) +
+    ggplot2::xlim(0, NA) +
     ggplot2::ylim(0, 100) +
     ggplot2::scale_color_identity() +
     ggplot2::scale_shape_manual(

--- a/R/surface_hl.R
+++ b/R/surface_hl.R
@@ -209,6 +209,8 @@ plot_surface_hl <- function(sfc, step = 0.5) {
     ggplot2::scale_y_continuous(
       sec.axis = ggplot2::sec_axis(sfc, name = "hue")
     ) +
+    ggplot2::xlim(0, NA) +
+    ggplot2::ylim(0, 100) +
     ggplot2::scale_fill_identity() +
     ggplot2::labs(
       x = "chroma",


### PR DESCRIPTION
Fix #35 

This will set the default limits for all our plots so that it contains the entire luminance domain as well as the zero-chroma limit.

@haleyjeppson - this is not a breaking change, but you may find it useful